### PR TITLE
ContentChangesEvent: Notify of content creation

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/content_service/service/ContentService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/content_service/service/ContentService.java
@@ -256,6 +256,9 @@ public class ContentService {
     private <T extends ContentEntity> T createContent(T contentEntity, final UUID courseId) {
         contentEntity.getMetadata().setCourseId(courseId);
         contentEntity = contentRepository.save(contentEntity);
+
+        topicPublisher.notifyContentChanges(List.of(contentEntity.getId()), CrudOperation.CREATE);
+
         return contentEntity;
     }
 


### PR DESCRIPTION
Makes the ContentChangesEvent be raised with CrudOperation.CREATE when a new content entity is created